### PR TITLE
Fixes bug where new show can't add cast members.

### DIFF
--- a/apps/app.js
+++ b/apps/app.js
@@ -72,7 +72,7 @@ playbills.controller('PostController', ['$scope', '$routeParams', '$http', '$loc
         $scope.template = $scope.templates[0];
       }).
       error(function(data, status, headers, config) {
-        $scope.show = {};
+        $scope.show = { cast: [] };
       });
 
     // edit the post
@@ -143,9 +143,6 @@ playbills.controller('PostController', ['$scope', '$routeParams', '$http', '$loc
 
 playbills.controller('CastController', ['$scope',
   function($scope){
-    if(!$scope.show)      { $scope.show = {};                }
-    if(!$scope.show.cast) { $scope.show.cast = []; }
-
     $scope.addNewActor = function() {
       var itemNo = $scope.show.cast.length;
       $scope.show.cast.push({'name': '' , 'index': itemNo});


### PR DESCRIPTION
The CastController relies on a certain show structure for adding an actor: there must be a show object, and there must also be a cast array into which actors can be added. In the CastController, I ensured that there would be a show object with the proper format by checking to see if there was a valid show, and if not, I would add one. 

The problem with adding the show to the CastController is that it was not in the same scope as the PostController. I had created two shows in different scopes, and was adding data to both of them.

![image](https://cloud.githubusercontent.com/assets/1517356/6620215/c5ab6d86-c88c-11e4-9ae9-5e91d13d777c.png)

Of course, this doesn't happen in the edit form, because there is already a valid show! 

The solution is to remove the error checking in the CastController, and to ensure that the show has the proper data format in the PostController - whether it is fetched from the database or not.


fixes #37 